### PR TITLE
[Refactor] Remove gRPC SSL Target Override Option

### DIFF
--- a/src/cli-client/cli_client.py
+++ b/src/cli-client/cli_client.py
@@ -69,8 +69,7 @@ class SpeechCenterClient:
     def run(self):
         logging.info("Running CSR inference example...")
         # Open connection to grpc channel to provided host.
-        with grpc.secure_channel(self.host, credentials=self.credentials.get_channel_credentials(),
-                                 options=(('grpc.ssl_target_name_override', 'speech-center.verbio.com'),)) as channel:
+        with grpc.secure_channel(self.host, credentials=self.credentials.get_channel_credentials()) as channel:
             # Instantiate a speech_recognizer to manage grpc calls to backend.
             speech_recognizer = verbio_speech_center_pb2_grpc.SpeechRecognizerStub(channel)
             try:


### PR DESCRIPTION
**Description**: [Refactor] Remove gRPC SSL Target Override Option

**Motivation and Context**

This pull request is intended to remove a gRPC secure channel option called `ssl_target_name_override`, which is only meant for testing purposes only, as described in the [proto file definition](https://github.com/grpc/grpc/blob/v1.43.x/include/grpc/impl/codegen/grpc_types.h#L270-L277).

This option was necessary when the SSL configuration was not ready for the service and an IP address had to be called instead. Currently, this option has become obsolete.

