### PR TITLE
[Refactor] Remove language option from mutually exclusive arguments group

### DIFF
--- a/src/cli-client/cli_client.py
+++ b/src/cli-client/cli_client.py
@@ -126,7 +126,7 @@ def parse_command_line() -> Options:
     argGroup = parser.add_mutually_exclusive_group(required=True)
     argGroup.add_argument('--grammar', '-g', help='Path to a file containing an ABNF grammar')
     argGroup.add_argument('--topic', '-T', choices=['GENERIC', 'TELCO', 'BANKING'], help='A valid topic')
-    argGroup.add_argument('--language','-l', choices=['en-US', 'pt-BR', 'es-ES'], help='Language Id. (default: ' + options.language + ')', default=options.language)
+    parser.add_argument('--language','-l', choices=['en-US', 'pt-BR', 'es-ES'], help='Language Id. (default: ' + options.language + ')', default=options.language)
     parser.add_argument('--token', '-t', help='A string with the authentication token', required=True)
     parser.add_argument('--host', '-H', help='The URL of the host trying to reach (default: ' + options.host + ')',
                         default=options.host)


### PR DESCRIPTION
**Description**: [Refactor] Remove language option from mutually exclusive arguments group

**Motivation and Context**

This pull request is intended to remove a from the an arguments mutually exclusive group the language option, which should be an independent parameter.

Before the changes, the help message displayed as:

![Captura de pantalla de 2022-02-01 15-16-32](https://user-images.githubusercontent.com/72133824/151985766-dabc5fe2-bc8b-4c5b-85b2-f54efcaa1db1.png)

After the changes, the help message exhibits:

![Captura de pantalla de 2022-02-01 15-16-43](https://user-images.githubusercontent.com/72133824/151985827-f61fa142-8b80-4fe8-b6d3-df295f76191e.png)


