### PR TITLE
Feature/ Handle STT gRPC Streaming EOF

### DIFF
--- a/cli-client/helpers/csr_client.py
+++ b/cli-client/helpers/csr_client.py
@@ -57,6 +57,9 @@ class CSRClient:
                         self._inactivity_timer.cancel()
                     self._start_inactivity_timer(self._inactivity_timer_timeout)
 
+            self._inactivity_timer.cancel()
+            self._peer_responded.set()
+
         except Exception as e:
             logging.error("Error running response watcher: %s", str(e))
             self._peer_responded.set()


### PR DESCRIPTION
When the gRPC response stream ends due to EOF, cancel the current inactivity timer and signal the recognition process end.

## How to Test

Run and time a gRPC streaming recognition request both from the `main` and the current branches. Then, compare the total processing time.

Example request:

```shell
> cd cli-client
> time python3 ./recognizer_stream.py  --audio-file my_audio.wav --language en-US --token token --asr-version=V2 --host us.speechcenter.verbio.com --topic GENERIC
```